### PR TITLE
Update for Rails 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails Forms Overview
 
-**Note:** This lesson is written for students working on legacy Rails codebases that still use `form_tag` and `form_for`. In the current versions of Rails, these helpers are considered legacy and should not be used in new code. The modern and recommended approach is to use `form_with`, which is covered below. However, you will encounter `form_tag` and `form_for` in older projects, so it is important to understand them.
+> **Note:** This lesson is written for students working on legacy Rails codebases that still use `form_tag` and `form_for`. In the current versions of Rails, these helpers are considered legacy and should not be used in new code. The modern and recommended approach is to use `form_with`, which is covered below. However, you will encounter `form_tag` and `form_for` in older projects, so it is important to understand them.
 
 Imagine that you're on a roadtrip across the country (I'm already jealous) with
 a starting point of Santa Barbara and a final destination of New York City. If
@@ -208,11 +208,11 @@ To summarize the differences:
 
 ## Quick Reference Table
 
-| Helper      | Use Case                        | Legacy? | Notes                                  |
-|-------------|----------------------------------|---------|----------------------------------------|
-| form_tag    | Forms not tied to a model        | Yes     | Use only in legacy codebases           |
-| form_for    | Forms tied to a model (CRUD)     | Yes     | Use only in legacy codebases           |
-| form_with   | All new forms (model or not)     | No      | Preferred for all new Rails code       |
+| Helper      | Use Case                        | Notes                                  |
+|-------------|----------------------------------|----------------------------------------|
+| form_tag    | Forms not tied to a model        | Use only in legacy codebases           |
+| form_for    | Forms tied to a model (CRUD)     | Use only in legacy codebases           |
+| form_with   | All new forms (model or not)     | Preferred for all new Rails code       |
 
 **References:**
 - [Rails Guides: Form Helpers](https://guides.rubyonrails.org/form_helpers.html)


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the current best practices for building forms in Rails. It introduces clear guidance on the legacy status of `form_tag` and `form_for`, and adds comprehensive documentation for the modern `form_with` helper, including practical examples and explanations of parameter handling. The changes help students understand which form helpers to use for new code and how to work with legacy codebases.

**Form Helper Modernization and Documentation:**

* Added prominent notices that both `form_tag` and `form_for` are legacy helpers, and explained that `form_with` is the recommended approach for all new Rails code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R37) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R77)
* Introduced a new section detailing the usage of `form_with`, including code examples for forms with and without models, and explained the impact of the `local: true` option.
* Added explanations on how all three helpers generate similar nested params structures, and included a section on handling strong parameters in Rails controllers.

**Comparison and Reference Material:**

* Rewrote and expanded the section comparing `form_with`, `form_for`, and `form_tag`, clarifying when and why to use each helper.
* Added a quick reference table summarizing the use cases and legacy status of each form helper, and included a link to the official Rails Guides for further reading.